### PR TITLE
Last-resort exclusion list for FL images

### DIFF
--- a/LSSTCam/bad_for_FL.ecsv
+++ b/LSSTCam/bad_for_FL.ecsv
@@ -1,0 +1,12 @@
+# %ECSV 1.0
+# ---
+# datatype:
+# - {name: exposure, datatype: uint64}
+# - {name: detector, datatype: uint64}
+# - {name: comment, datatype: string}
+# delimiter: ','
+# schema: astropy-2.0
+exposure,detector,comment
+2025050100443,149,satellite
+2025050200272,96,satellite
+2025050300429,91,satellite


### PR DESCRIPTION
Adding this just for artifacts leaking into the FL coadds that we can't find any other way to exclude. I don't want this to become a general "if you see a satellite you have to add it here" list; the vast majority of satellites were already successfully removed from the coadds, this is just a field-expedient cleanup pass.