### PR TITLE
20250609: Add focus/rotator failures during all_sky_aos_test

### DIFF
--- a/LSSTCam/bad.ecsv
+++ b/LSSTCam/bad.ecsv
@@ -71,3 +71,25 @@ exposure,comment
 2025060400412, trailed
 2025060400415, trailed
 2025060400416, trailed
+2025060900437, all_sky_aos_test donuts
+2025060900436, all_sky_aos_test donuts
+2025060900435, all_sky_aos_test donuts
+2025060900434, all_sky_aos_test donuts
+2025060900433, all_sky_aos_test rotator failed
+2025060900432, all_sky_aos_test donuts
+2025060900431, all_sky_aos_test donuts
+2025060900430, all_sky_aos_test donuts
+2025060900384, all_sky_aos_test donuts
+2025060900383, all_sky_aos_test donuts
+2025060900382, all_sky_aos_test donuts
+2025060900381, all_sky_aos_test donuts
+2025060900380, all_sky_aos_test donuts
+2025060900379, all_sky_aos_test donuts
+2025060900378, all_sky_aos_test rotator failed
+2025060900304, all_sky_aos_test rotator failed on donuts
+2025060900303, all_sky_aos_test donuts
+2025060900302, all_sky_aos_test donuts
+2025060900301, all_sky_aos_test donuts
+2025060900300, all_sky_aos_test donuts
+2025060900299, all_sky_aos_test donuts
+2025060900298, all_sky_aos_test donuts


### PR DESCRIPTION
I'm on the fence on whether to merge this. Focus and rotator issues are so ubiquitous when running all_sky_aos_test that I don't think we're actually going to ever process  all_sky_aos_test  from these early days. 